### PR TITLE
DynamoDB: Fix serializing empty strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- DynamoDB: Fix `String Set` and `Number Set` representation for CrateDB
+- DynamoDB: Fix serializing empty strings
 
 ## 2024/08/20 v0.0.8
 - DynamoDB: Apply rough type evaluation and dispatching when computing

--- a/src/commons_codec/transform/dynamodb.py
+++ b/src/commons_codec/transform/dynamodb.py
@@ -9,7 +9,6 @@ import typing as t
 import simplejson as json
 import toolz
 
-from commons_codec.util.data import is_container, is_number
 from commons_codec.vendor.boto3.dynamodb.types import DYNAMODB_CONTEXT, TypeDeserializer
 
 logger = logging.getLogger(__name__)
@@ -169,7 +168,9 @@ class DynamoCDCTranslatorCrateDB(DynamoCDCTranslatorBase):
 
         constraints: t.List[str] = []
         for key_name, key_value in values_clause.items():
-            if not is_container(key_value) and not is_number(key_value):
+            if key_value is None:
+                key_value = "NULL"
+            elif isinstance(key_value, str):
                 key_value = "'" + str(key_value).replace("'", "''") + "'"
             constraint = f"{self.DATA_COLUMN}['{key_name}'] = {key_value}"
             constraints.append(constraint)

--- a/src/commons_codec/util/data.py
+++ b/src/commons_codec/util/data.py
@@ -30,7 +30,3 @@ def is_number(s):
         pass
 
     return False
-
-
-def is_container(value):
-    return isinstance(value, (dict, list, set))

--- a/tests/transform/test_dynamodb.py
+++ b/tests/transform/test_dynamodb.py
@@ -82,6 +82,8 @@ MSG_MODIFY_BASIC = {
             "string_set": {"SS": ["location_1"]},
             "number_set": {"NS": [1, 2, 3, 0.34]},
             "binary_set": {"BS": ["U3Vubnk="]},
+            "empty_string": {"S": ""},
+            "null_string": {"S": None},
         },
         "OldImage": {
             "humidity": {"N": "84.84"},
@@ -197,7 +199,7 @@ def test_decode_cdc_modify_basic():
         DynamoCDCTranslatorCrateDB(table_name="foo").to_sql(MSG_MODIFY_BASIC) == 'UPDATE "foo" '
         "SET data['humidity'] = 84.84, data['temperature'] = 55.66, data['location'] = 'Sydney', "
         "data['string_set'] = ['location_1'], data['number_set'] = [0.34, 1.0, 2.0, 3.0],"
-        " data['binary_set'] = ['U3Vubnk=']"
+        " data['binary_set'] = ['U3Vubnk='], data['empty_string'] = '', data['null_string'] = NULL"
         " WHERE data['device'] = 'foo' AND data['timestamp'] = '2024-07-12T01:17:42';"
     )
 


### PR DESCRIPTION
## Problem
The translator produced invalid SQL when processing empty strings.
```sql
data['notes'] = ,
```