### PR TITLE
DynamoDB: Fix serializing OBJECT and ARRAY representations to CrateDB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- DynamoDB: Fix serializing OBJECT and ARRAY representations to CrateDB
 
 ## 2024/08/22 v0.0.10
 - DynamoDB: Fix `Map` representation to CrateDB.

--- a/src/commons_codec/transform/dynamodb.py
+++ b/src/commons_codec/transform/dynamodb.py
@@ -177,20 +177,8 @@ class DynamoCDCTranslatorCrateDB(DynamoCDCTranslatorBase):
                 # TODO: Does it also need escaping of inner TEXT values, like the above?
                 key_value = "'" + json.dumps(key_value) + "'::OBJECT"
 
-            # TODO: ARRAY types do not support JSON syntax yet.
-            #       Let's relay them 1:1, which works for primitive inner types,
-            #       but complex ones need special treatment, like representing
-            #       OBJECTs in CrateDB-native syntax.
-            # FIXME: Find a way to use a custom JSONEncoder for that, in order to
-            #        fully support also nested elements of those.
-            # https://github.com/crate/commons-codec/issues/33
-            elif isinstance(key_value, list):
-                if key_value:
-                    if isinstance(key_value[0], dict):
-                        items = []
-                        for item in key_value:
-                            items.append("{" + ", ".join(f"{key}='{value}'" for key, value in item.items()) + "}")
-                        key_value = "[" + ",".join(items) + "]"
+            elif isinstance(key_value, list) and key_value and isinstance(key_value[0], dict):
+                key_value = "'" + json.dumps(key_value) + "'::OBJECT[]"
 
             constraint = f"{self.DATA_COLUMN}['{key_name}'] = {key_value}"
             constraints.append(constraint)

--- a/tests/transform/test_dynamodb.py
+++ b/tests/transform/test_dynamodb.py
@@ -228,7 +228,7 @@ def test_decode_cdc_modify_nested():
         "SET data['tags'] = ['foo', 'bar'], data['empty_map'] = '{}'::OBJECT, data['empty_list'] = [],"
         " data['string_set'] = ['location_1'], data['number_set'] = [0.34, 1.0, 2.0, 3.0],"
         " data['binary_set'] = ['U3Vubnk='], data['somemap'] = '{\"test\": 1.0, \"test2\": 2.0}'::OBJECT,"
-        " data['list_of_objects'] = [{foo='bar'},{baz='qux'}]"
+        ' data[\'list_of_objects\'] = \'[{"foo": "bar"}, {"baz": "qux"}]\'::OBJECT[]'
         " WHERE data['device'] = 'foo' AND data['timestamp'] = '2024-07-12T01:17:42';"
     )
 

--- a/tests/transform/test_dynamodb.py
+++ b/tests/transform/test_dynamodb.py
@@ -127,6 +127,7 @@ MSG_MODIFY_NESTED = {
                     "test2": {"N": 2},
                 }
             },
+            "list_of_objects": {"L": [{"M": {"foo": {"S": "bar"}}}, {"M": {"baz": {"S": "qux"}}}]},
         },
         "OldImage": {
             "humidity": {"N": "84.84"},
@@ -224,9 +225,10 @@ def test_decode_cdc_modify_basic():
 def test_decode_cdc_modify_nested():
     assert (
         DynamoCDCTranslatorCrateDB(table_name="foo").to_sql(MSG_MODIFY_NESTED) == 'UPDATE "foo" '
-        "SET data['tags'] = ['foo', 'bar'], data['empty_map'] = '{}', data['empty_list'] = [],"
+        "SET data['tags'] = ['foo', 'bar'], data['empty_map'] = '{}'::OBJECT, data['empty_list'] = [],"
         " data['string_set'] = ['location_1'], data['number_set'] = [0.34, 1.0, 2.0, 3.0],"
-        " data['binary_set'] = ['U3Vubnk='], data['somemap'] = '{\"test\": 1.0, \"test2\": 2.0}'"
+        " data['binary_set'] = ['U3Vubnk='], data['somemap'] = '{\"test\": 1.0, \"test2\": 2.0}'::OBJECT,"
+        " data['list_of_objects'] = [{foo='bar'},{baz='qux'}]"
         " WHERE data['device'] = 'foo' AND data['timestamp'] = '2024-07-12T01:17:42';"
     )
 


### PR DESCRIPTION
## About
Another attempt to get relaying container type values right, this time for both OBJECTs and ARRAYs, at least a basic variant thereof, in order to unblock people needing it.

## Details
The problem with ARRAYs is that they can't be relayed using JSON syntax, supported by a corresponding CAST. Instead, we need to use the native notation of CrateDB, which works without much ado on primitive inner types.

When serializing ARRAYs including OBJECT inner types, we need to actively convert to CrateDB's native syntax, which is close to Python's `dict(foo='bar')` syntax notation.

## References
- GH-33
