### PR TITLE
DMS/DynamoDB/MongoDB: Use SQL with parameters instead of inlining values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- DMS/DynamoDB/MongoDB: Use SQL with parameters instead of inlining values
 
 ## 2024/08/23 v0.0.11
 - DynamoDB: Fix serializing OBJECT and ARRAY representations to CrateDB

--- a/src/commons_codec/model.py
+++ b/src/commons_codec/model.py
@@ -3,12 +3,13 @@ import sys
 import typing as t
 from enum import auto
 
+from attr import Factory
+from attrs import define
+
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
     from backports.strenum import StrEnum  # pragma: no cover
-
-from attrs import define
 
 
 @define(frozen=True)
@@ -81,3 +82,33 @@ class ColumnTypeMapStore(dict):
         if not payload:
             return None
         return cls.from_dict(json.loads(payload))
+
+
+@define
+class SQLOperation:
+    """
+    Bundle data about an SQL operation, including statement and parameters.
+
+    Parameters can be a single dictionary or a list of dictionaries.
+    """
+
+    statement: str
+    parameters: t.Optional[t.Union[t.Mapping[str, t.Any], t.List[t.Mapping[str, t.Any]]]] = None
+
+
+@define
+class SQLParameterizedClause:
+    """
+    Manage details about a SQL parameterized clause, including column names, parameter names, and values.
+    """
+
+    columns: t.List[str] = Factory(list)
+    names: t.List[str] = Factory(list)
+    values: t.List[str] = Factory(list)
+
+    @property
+    def set_clause(self):
+        """
+        Render a SET clause of an SQL statement.
+        """
+        return ", ".join([f"{key}={value}" for key, value in zip(self.columns, self.names)])

--- a/src/commons_codec/transform/aws_dms.py
+++ b/src/commons_codec/transform/aws_dms.py
@@ -9,7 +9,14 @@ import typing as t
 import simplejson as json
 
 from commons_codec.exception import MessageFormatError, UnknownOperationError
-from commons_codec.model import ColumnType, ColumnTypeMapStore, PrimaryKeyStore, TableAddress
+from commons_codec.model import (
+    ColumnType,
+    ColumnTypeMapStore,
+    PrimaryKeyStore,
+    SQLOperation,
+    SQLParameterizedClause,
+    TableAddress,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,35 +73,39 @@ class DMSTranslatorCrateDBRecord:
         self.primary_keys: t.List[str] = self.container.primary_keys[self.address]
         self.column_types: t.Dict[str, ColumnType] = self.container.column_types[self.address]
 
-    def to_sql(self) -> str:
+    def to_sql(self) -> SQLOperation:
         if self.operation == "create-table":
             pks = self.control.get("table-def", {}).get("primary-key")
             if pks:
                 self.primary_keys += pks
             # TODO: What about dropping tables first?
-            return f"CREATE TABLE IF NOT EXISTS {self.address.fqn} ({self.DATA_COLUMN} OBJECT(DYNAMIC));"
+            return SQLOperation(f"CREATE TABLE IF NOT EXISTS {self.address.fqn} ({self.DATA_COLUMN} OBJECT(DYNAMIC));")
 
         elif self.operation in ["load", "insert"]:
-            values_clause = self.record_to_values()
-            sql = f"INSERT INTO {self.address.fqn} ({self.DATA_COLUMN}) VALUES ('{values_clause}');"
+            record = self.record_to_values()
+            sql = f"INSERT INTO {self.address.fqn} ({self.DATA_COLUMN}) VALUES (:record);"
+            parameters = {"record": record}
 
         elif self.operation == "update":
-            values_clause = self.record_to_update()
+            record = self.record_to_values()
+            clause = self.update_clause()
             where_clause = self.keys_to_where()
-            sql = f"UPDATE {self.address.fqn} SET {values_clause} WHERE {where_clause};"
+            sql = f"UPDATE {self.address.fqn} SET {clause.set_clause} WHERE {where_clause};"
+            parameters = {"record": record}
 
         elif self.operation == "delete":
             where_clause = self.keys_to_where()
             sql = f"DELETE FROM {self.address.fqn} WHERE {where_clause};"
+            parameters = None
 
         else:
             message = f"Unknown CDC event operation: {self.operation}"
             logger.warning(message)
             raise UnknownOperationError(message, operation=self.operation, record=self.record)
 
-        return sql
+        return SQLOperation(sql, parameters)
 
-    def record_to_update(self) -> str:
+    def update_clause(self) -> SQLParameterizedClause:
         """
         Serializes an image to a comma-separated list of column/values pairs
         that can be used in the `SET` clause of an `UPDATE` statement.
@@ -106,17 +117,21 @@ class DMSTranslatorCrateDBRecord:
         OUT
         data['age'] = '33', data['attributes'] = '{"foo": "bar"}', data['name'] = 'John'
         """
-        constraints: t.List[str] = []
-        for column_name, column_value in self.record["data"].items():
+        clause = SQLParameterizedClause()
+        for column, value in self.record["data"].items():
             # Skip primary key columns, they cannot be updated
-            if column_name in self.primary_keys:
+            if column in self.primary_keys:
                 continue
 
-            constraint = f"{self.DATA_COLUMN}['{column_name}'] = '{column_value}'"
-            constraints.append(constraint)
-        return ", ".join(constraints)
+            param_name = f":{column}"
 
-    def record_to_values(self) -> str:
+            clause.columns.append(f"{self.DATA_COLUMN}['{column}']")
+            clause.names.append(param_name)
+            clause.values.append(value)  # noqa: PD011
+
+        return clause
+
+    def record_to_values(self) -> t.Dict[str, t.Any]:
         """
         Apply type translations to record, and serialize to JSON.
 
@@ -133,7 +148,7 @@ class DMSTranslatorCrateDBRecord:
                 if column_type is ColumnType.MAP and isinstance(value, str):
                     value = json.loads(value)
                 self.data[column_name] = value
-        return json.dumps(self.data)
+        return self.data
 
     def keys_to_where(self) -> str:
         """
@@ -169,7 +184,7 @@ class DMSTranslatorCrateDB:
         self.primary_keys = primary_keys or PrimaryKeyStore()
         self.column_types = column_types or ColumnTypeMapStore()
 
-    def to_sql(self, record: t.Dict[str, t.Any]) -> str:
+    def to_sql(self, record: t.Dict[str, t.Any]) -> SQLOperation:
         """
         Produce INSERT|UPDATE|DELETE SQL statement from load|insert|update|delete CDC event record.
         """

--- a/tests/transform/test_dynamodb_full.py
+++ b/tests/transform/test_dynamodb_full.py
@@ -1,0 +1,41 @@
+from commons_codec.model import SQLOperation
+from commons_codec.transform.dynamodb import DynamoDBFullLoadTranslator
+
+RECORD = {
+    "id": {"S": "5F9E-Fsadd41C-4C92-A8C1-70BF3FFB9266"},
+    "data": {"M": {"temperature": {"N": "42.42"}, "humidity": {"N": "84.84"}}},
+    "meta": {"M": {"timestamp": {"S": "2024-07-12T01:17:42"}, "device": {"S": "foo"}}},
+    "string_set": {"SS": ["location_1"]},
+    "number_set": {"NS": [1, 2, 3, 0.34]},
+    "binary_set": {"BS": ["U3Vubnk="]},
+    "somemap": {
+        "M": {
+            "test": {"N": 1},
+            "test2": {"N": 2},
+        }
+    },
+}
+
+
+def test_sql_ddl():
+    assert (
+        DynamoDBFullLoadTranslator(table_name="foo").sql_ddl
+        == 'CREATE TABLE IF NOT EXISTS "foo" (data OBJECT(DYNAMIC));'
+    )
+
+
+def test_to_sql():
+    assert DynamoDBFullLoadTranslator(table_name="foo").to_sql(RECORD) == SQLOperation(
+        statement='INSERT INTO "foo" (data) VALUES (:record);',
+        parameters={
+            "record": {
+                "id": "5F9E-Fsadd41C-4C92-A8C1-70BF3FFB9266",
+                "data": {"temperature": 42.42, "humidity": 84.84},
+                "meta": {"timestamp": "2024-07-12T01:17:42", "device": "foo"},
+                "string_set": ["location_1"],
+                "number_set": [0.34, 1.0, 2.0, 3.0],
+                "binary_set": ["U3Vubnk="],
+                "somemap": {"test": 1.0, "test2": 2.0},
+            }
+        },
+    )


### PR DESCRIPTION
## About
At the core of this patch is the introduction of the `SQLOperation` class, which bundles together an SQL statement and its parameters, in order to convey those instances to callers, instead of rendering a full-fledged SQL statement in string format, which is problematic because of string escaping issues.

https://github.com/crate/commons-codec/blob/3f9dfe5a8e55e7024b18b852778d27d4408551e7/src/commons_codec/model.py#L87-L96

## Details
- `SQLOperation` bundles data about an SQL operation, including statement and parameters.
- `DynamoDBFullLoadTranslator` supports full-load data transfers.

## References
This patch will need relevant adjustments in CrateDB Toolkit, effectively converging into releases of both packages in lock-step.

- https://github.com/crate/cratedb-toolkit/pull/243

/cc @surister, @hammerhead, @hlcianfagna 