### PR TITLE
DMS/DynamoDB: Use parameterized SQL WHERE clauses instead of inlining

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- DMS/DynamoDB: Use parameterized SQL WHERE clauses instead of inlining values
 
 ## 2024/08/26 v0.0.12
 - DMS/DynamoDB/MongoDB: Use SQL with parameters instead of inlining values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,8 @@ lint.extend-ignore = [
   "RET505",
   # Probable insecure usage of temporary file or directory
   "S108",
+  # Possible SQL injection vector through string-based query construction
+  "S608",
 ]
 
 lint.per-file-ignores."examples/*" = [

--- a/tests/transform/test_aws_dms.py
+++ b/tests/transform/test_aws_dms.py
@@ -240,8 +240,8 @@ def test_decode_cdc_update_success(cdc):
     assert cdc.to_sql(MSG_DATA_UPDATE_VALUE) == SQLOperation(
         statement='UPDATE "public"."foo" SET '
         "data['age']=:age, data['attributes']=:attributes, data['name']=:name "
-        "WHERE data['id'] = '42';",
-        parameters={"record": RECORD_UPDATE},
+        "WHERE data['id']=:id;",
+        parameters=RECORD_UPDATE,
     )
 
 
@@ -267,7 +267,7 @@ def test_decode_cdc_delete_success(cdc):
 
     # Emulate a DELETE operation.
     assert cdc.to_sql(MSG_DATA_DELETE) == SQLOperation(
-        statement="DELETE FROM \"public\".\"foo\" WHERE data['id'] = '45';", parameters=None
+        statement='DELETE FROM "public"."foo" WHERE data[\'id\']=:id;', parameters={"id": 45}
     )
 
 

--- a/tests/transform/test_dynamodb_cdc.py
+++ b/tests/transform/test_dynamodb_cdc.py
@@ -234,8 +234,10 @@ def test_decode_cdc_modify_basic():
         "data['humidity']=:humidity, data['temperature']=:temperature, data['location']=:location, "
         "data['string_set']=:string_set, data['number_set']=:number_set, data['binary_set']=:binary_set, "
         "data['empty_string']=:empty_string, data['null_string']=:null_string "
-        "WHERE data['device'] = 'foo' AND data['timestamp'] = '2024-07-12T01:17:42';",
+        "WHERE data['device']=:device AND data['timestamp']=:timestamp;",
         parameters={
+            "device": "foo",
+            "timestamp": "2024-07-12T01:17:42",
             "humidity": 84.84,
             "temperature": 55.66,
             "location": "Sydney",
@@ -254,8 +256,10 @@ def test_decode_cdc_modify_nested():
         "data['tags']=:tags, data['empty_map']=CAST(:empty_map AS OBJECT), data['empty_list']=:empty_list, "
         "data['string_set']=:string_set, data['number_set']=:number_set, data['binary_set']=:binary_set, "
         "data['somemap']=CAST(:somemap AS OBJECT), data['list_of_objects']=CAST(:list_of_objects AS OBJECT[]) "
-        "WHERE data['device'] = 'foo' AND data['timestamp'] = '2024-07-12T01:17:42';",
+        "WHERE data['device']=:device AND data['timestamp']=:timestamp;",
         parameters={
+            "device": "foo",
+            "timestamp": "2024-07-12T01:17:42",
             "tags": ["foo", "bar"],
             "empty_map": {},
             "empty_list": [],
@@ -270,8 +274,11 @@ def test_decode_cdc_modify_nested():
 
 def test_decode_cdc_remove():
     assert DynamoDBCDCTranslator(table_name="foo").to_sql(MSG_REMOVE) == SQLOperation(
-        statement="DELETE FROM \"foo\" WHERE data['device'] = 'bar' AND data['timestamp'] = '2024-07-12T01:17:42';",
-        parameters=None,
+        statement="DELETE FROM \"foo\" WHERE data['device']=:device AND data['timestamp']=:timestamp;",
+        parameters={
+            "device": "bar",
+            "timestamp": "2024-07-12T01:17:42",
+        },
     )
 
 


### PR DESCRIPTION
## About
Following up on https://github.com/crate/commons-codec/pull/35#pullrequestreview-2260314090, this patch also introduces parameterized WHERE clauses within the DMS and DynamoDB I/O adapter implementations.

## Validation
That other PR validates the patch on behalf of CrateDB Toolkit.
- https://github.com/crate/cratedb-toolkit/pull/244