### PR TITLE
DynamoDB: Compress transformation tests into single one. Naming things.

### DIFF
--- a/tests/transform/test_dynamodb_full.py
+++ b/tests/transform/test_dynamodb_full.py
@@ -5,20 +5,14 @@ RECORD_ALL_TYPES = {
     "id": {"S": "5F9E-Fsadd41C-4C92-A8C1-70BF3FFB9266"},
     "data": {"M": {"temperature": {"N": "42.42"}, "humidity": {"N": "84.84"}}},
     "meta": {"M": {"timestamp": {"S": "2024-07-12T01:17:42"}, "device": {"S": "foo"}}},
-    "string_set": {"SS": ["location_1"]},
-    "number_set": {"NS": [1, 2, 3, 0.34]},
-    "binary_set": {"BS": ["U3Vubnk="]},
-    "somemap": {
+    "location": {
         "M": {
-            "test": {"N": 1},
-            "test2": {"N": 2},
-        }
+            "coordinates": {"L": [{"S": ""}]},
+            "meetingPoint": {"S": "At the end of the tunnel"},
+            "address": {"S": "Berchtesgaden Salt Mine"},
+        },
     },
-    "list_varied": {"L": [{"M": {"a": {"N": 1}}}, {"N": 2}, {"S": "Three"}]},
-}
-
-RECORD_UTM = {
-    "utmTags": {
+    "list_of_objects": {
         "L": [
             {
                 "M": {
@@ -30,7 +24,17 @@ RECORD_UTM = {
                 }
             }
         ]
-    }
+    },
+    "list_of_varied": {"L": [{"M": {"a": {"N": 1}}}, {"N": 2}, {"S": "Three"}]},
+    "map_of_numbers": {
+        "M": {
+            "test": {"N": 1},
+            "test2": {"N": 2},
+        }
+    },
+    "set_of_binaries": {"BS": ["U3Vubnk="]},
+    "set_of_numbers": {"NS": [1, 2, 3, 0.34]},
+    "set_of_strings": {"SS": ["location_1"]},
 }
 
 
@@ -49,28 +53,14 @@ def test_to_sql_all_types():
                 "id": "5F9E-Fsadd41C-4C92-A8C1-70BF3FFB9266",
                 "data": {"temperature": 42.42, "humidity": 84.84},
                 "meta": {"timestamp": "2024-07-12T01:17:42", "device": "foo"},
-                "string_set": ["location_1"],
-                "number_set": [0.34, 1.0, 2.0, 3.0],
-                "binary_set": ["U3Vubnk="],
-                "somemap": {"test": 1.0, "test2": 2.0},
-            },
-            "untyped": {
-                "list_varied": [
-                    {"a": 1.0},
-                    2.0,
-                    "Three",
-                ],
-            },
-        },
-    )
-
-
-def test_to_sql_list_of_objects():
-    assert DynamoDBFullLoadTranslator(table_name="foo").to_sql(RECORD_UTM) == SQLOperation(
-        statement="INSERT INTO foo (data, aux) VALUES (:typed, :untyped);",
-        parameters={
-            "typed": {
-                "utmTags": [
+                "location": {
+                    "address": "Berchtesgaden Salt Mine",
+                    "coordinates": [
+                        "",
+                    ],
+                    "meetingPoint": "At the end of the tunnel",
+                },
+                "list_of_objects": [
                     {
                         "date": "2024-08-28T20:05:42.603Z",
                         "utm_adgroup": ["", ""],
@@ -78,8 +68,18 @@ def test_to_sql_list_of_objects():
                         "utm_medium": "foobar",
                         "utm_source": "google",
                     }
-                ]
+                ],
+                "map_of_numbers": {"test": 1.0, "test2": 2.0},
+                "set_of_binaries": ["U3Vubnk="],
+                "set_of_numbers": [0.34, 1.0, 2.0, 3.0],
+                "set_of_strings": ["location_1"],
             },
-            "untyped": {},
+            "untyped": {
+                "list_of_varied": [
+                    {"a": 1.0},
+                    2.0,
+                    "Three",
+                ],
+            },
         },
     )


### PR DESCRIPTION
## About
Apply a round of "naming things" and cleanups to DynamoDB tests.