### PR TITLE
DynamoDB: Improve `to_sql()` to accept list of records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   `quote_relation_name` from `sqlalchemy-cratedb` package.
 - DynamoDB: Add special decoding for varied lists, storing them into a separate
   `OBJECT(IGNORED)` column in CrateDB
+- DynamoDB: Improve `to_sql()` to accept list of records
 
 ## 2024/08/27 v0.0.13
 - DMS/DynamoDB: Use parameterized SQL WHERE clauses instead of inlining values

--- a/src/commons_codec/model.py
+++ b/src/commons_codec/model.py
@@ -139,3 +139,6 @@ class DualRecord:
 
     typed: t.Dict[str, t.Any]
     untyped: t.Dict[str, t.Any]
+
+    def to_dict(self):
+        return {"typed": self.typed, "untyped": self.untyped}

--- a/tests/transform/test_dynamodb_full.py
+++ b/tests/transform/test_dynamodb_full.py
@@ -89,10 +89,12 @@ def test_to_sql_operation():
     """
     assert DynamoDBFullLoadTranslator(table_name="foo").to_sql(RECORD_IN) == SQLOperation(
         statement="INSERT INTO foo (data, aux) VALUES (:typed, :untyped);",
-        parameters={
-            "typed": RECORD_OUT_DATA,
-            "untyped": RECORD_OUT_AUX,
-        },
+        parameters=[
+            {
+                "typed": RECORD_OUT_DATA,
+                "untyped": RECORD_OUT_AUX,
+            }
+        ],
     )
 
 
@@ -103,7 +105,7 @@ def test_to_sql_cratedb(caplog, cratedb):
 
     # Compute CrateDB operation (SQL+parameters) from DynamoDB record.
     translator = DynamoDBFullLoadTranslator(table_name="from.dynamodb")
-    operation = translator.to_sql(record=RECORD_IN)
+    operation = translator.to_sql(RECORD_IN)
 
     # Insert into CrateDB.
     cratedb.database.run_sql(translator.sql_ddl)


### PR DESCRIPTION
## About
In order to support batch operations, make the `to_sql()` method accept a list of records.

## References
- https://github.com/crate/cratedb-toolkit/pull/252

/cc @wierdvanderhaar, @hlcianfagna 