### PR TITLE
MongoDB: Fix edge case when decoding MongoDB Extended JSON elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- MongoDB: Fixed edge case when decoding MongoDB Extended JSON elements
 
 ## 2024/09/19 v0.0.16
 - MongoDB: Added `MongoDBFullLoadTranslator` and `MongoDBCrateDBConverter`

--- a/src/commons_codec/transform/mongodb.py
+++ b/src/commons_codec/transform/mongodb.py
@@ -71,7 +71,7 @@ class MongoDBCrateDBConverter:
         """
         if isinstance(value, dict):
             # Decode item in BSON CANONICAL format.
-            if len(value) == 1:
+            if len(value) == 1 and next(iter(value)).startswith("$"):
                 return self.decode_canonical(value)
 
             # Custom adjustments to compensate shape anomalies in source data.

--- a/tests/transform/mongodb/data.py
+++ b/tests/transform/mongodb/data.py
@@ -55,7 +55,7 @@ RECORD_IN_ALL_TYPES = {
     "canonical": {
         "code_ascii": {"$code": "abab"},
         "code_bytes": {"$code": "ab\u0000ab\u0000"},
-        "code_scope": {"$code": "abab", "$scope": {"x": {"$numberInt": 42}}},
+        "code_scope": {"$code": "abab", "$scope": {"x": {"$numberInt": "42"}}},
         "date_iso8601": {"$date": "2015-09-23T10:32:42.33Z"},
         "date_numberlong": {"$date": {"$numberLong": "1356351330000"}},
         "dbref": {
@@ -78,6 +78,7 @@ RECORD_IN_ALL_TYPES = {
         ],
         "list_dict": [
             {"id": "bar", "value": {"$date": "2015-09-24T10:32:42.33Z"}},
+            {"value": {"$date": "2015-09-24T10:32:42.33Z"}},
         ],
         "list_int": [
             {"$numberInt": "-2147483648"},
@@ -163,7 +164,7 @@ RECORD_OUT_ALL_TYPES = {
         "code_scope": {
             "$code": "abab",
             "$scope": {
-                "x": {"$numberInt": 42},
+                "x": 42,
             },
         },
         "date_iso8601": 1443004362000,
@@ -187,6 +188,7 @@ RECORD_OUT_ALL_TYPES = {
         ],
         "list_dict": [
             {"id": "bar", "value": 1443090762000},
+            {"value": 1443090762000},
         ],
         "list_int": [
             -2147483648,


### PR DESCRIPTION
## About
One more decoding fix for MongoDB Extended JSON elements.