### PR TITLE
Zyp and MongoDB: A few adjustments and refinements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   decode non-UUID binary values
 - Zyp/Moksha/jq: `to_object` function now respects a `zap` option, that
   removes the element altogether if it's empty
+- Zyp/Moksha/jq: Improve error reporting at `MokshaTransformation.apply`
 
 ## 2024/09/22 v0.0.17
 - MongoDB: Fixed edge case when decoding MongoDB Extended JSON elements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Zyp/Moksha/jq: `to_object` function now respects a `zap` option, that
   removes the element altogether if it's empty
 - Zyp/Moksha/jq: Improve error reporting at `MokshaTransformation.apply`
+- MongoDB: Improved `MongoDBCrateDBConverter.decode_extended_json`
 
 ## 2024/09/22 v0.0.17
 - MongoDB: Fixed edge case when decoding MongoDB Extended JSON elements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - MongoDB: Improved `MongoDBCrateDBConverter.decode_canonical` to also
   decode non-UUID binary values
+- Zyp/Moksha/jq: `to_object` function now respects a `zap` option, that
+  removes the element altogether if it's empty
 
 ## 2024/09/22 v0.0.17
 - MongoDB: Fixed edge case when decoding MongoDB Extended JSON elements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- MongoDB: Improved `MongoDBCrateDBConverter.decode_canonical` to also
+  decode non-UUID binary values
 
 ## 2024/09/22 v0.0.17
 - MongoDB: Fixed edge case when decoding MongoDB Extended JSON elements

--- a/doc/zyp/backlog.md
+++ b/doc/zyp/backlog.md
@@ -15,6 +15,28 @@
 - [ ] Documentation: Usage (build (API, from_yaml), apply)
 - [ ] Documentation: How to extend `function.{jq,py}`
 
+### Documentation
+```
+- Omit records `and .value.bill_contact.id != ""`
+# Only accept `email` elements that are objects.
+#and (if (.value | index("emails")) then (.value.emails[].type | type) == "object" else true end)
+
+# Exclude a few specific documents.
+# TODO: Review documents once more to discover more edge cases.
+.[] |= select(
+and ._id != "55d71c8ce4b02210dc47b10f"
+)
+
+# Some early `phone` elements have been stored wrongly,
+# all others are of type OBJECT.
+#and (.value.phone | type) != "array"
+
+# Some early `urls` elements have been stored wrongly,
+# all others are of type ARRAY.
+#and (.value.urls | type) != "object"
+```
+
+
 ## Iteration +2
 - [ ] CLI interface
 - [ ] Documentation: Add Python example to "Synopsis" section on /index.html
@@ -58,6 +80,8 @@ Demonstrate more use cases, like...
   - https://github.com/meltano/sdk/blob/v0.39.1/singer_sdk/mapper.py
 - [ ] Is `jqpy` better than `jq`?
   - https://baterflyrity.github.io/jqpy/
+- [ ] Load XML via Badgerfish or KDL
+  https://github.com/kdl-org/kdl
 
 ## Done
 - [x] Refactor module namespace to `zyp`

--- a/src/commons_codec/transform/mongodb.py
+++ b/src/commons_codec/transform/mongodb.py
@@ -124,17 +124,19 @@ class MongoDBCrateDBConverter:
         else:
             value = object_hook(value)
         is_bson = type(value).__module__.startswith("bson")
+
+        out: t.Any = value
         if isinstance(value, bson.Binary) and value.subtype == bson.UUID_SUBTYPE:
-            value = value.as_uuid()
+            out = value.as_uuid()
         elif isinstance(value, bson.Binary):
-            value = base64.b64encode(value).decode()
-        if isinstance(value, bson.Timestamp):
-            value = value.as_datetime()
-        if isinstance(value, dt.datetime):
-            return date_converter(value)
+            out = base64.b64encode(value).decode()
+        elif isinstance(value, bson.Timestamp):
+            out = value.as_datetime()
+        if isinstance(out, dt.datetime):
+            return date_converter(out)
         if is_bson:
-            return str(value)
-        return value
+            return str(out)
+        return out
 
     def apply_special_treatments(self, value: t.Any):
         """

--- a/src/commons_codec/transform/mongodb.py
+++ b/src/commons_codec/transform/mongodb.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021-2024, Crate.io Inc.
 # Distributed under the terms of the LGPLv3 license, see LICENSE.
 # ruff: noqa: S608
+import base64
 import calendar
 import datetime as dt
 import logging
@@ -125,6 +126,8 @@ class MongoDBCrateDBConverter:
         is_bson = type(value).__module__.startswith("bson")
         if isinstance(value, bson.Binary) and value.subtype == bson.UUID_SUBTYPE:
             value = value.as_uuid()
+        elif isinstance(value, bson.Binary):
+            value = base64.b64encode(value).decode()
         if isinstance(value, bson.Timestamp):
             value = value.as_datetime()
         if isinstance(value, dt.datetime):

--- a/src/zyp/function.jq
+++ b/src/zyp/function.jq
@@ -11,11 +11,21 @@ def to_array:
 
 def to_object(options):
     # Wrap element into object with given key if it isn't an object already.
+    # When option `zap: true`, remove element altogether because it is
+    # empty anyway, in the sense that it includes a single item with a
+    # null value.
     if . | type == "object" then
         .
     else
-        {(options.key): .}
-    end;
+        if . then
+            {(options.key): .}
+        end
+    end
+    |
+    if options.zap then
+        values
+    end
+    ;
 
 def is_array_of_objects:
     # Check if element is an array containing objects.

--- a/src/zyp/model/moksha.py
+++ b/src/zyp/model/moksha.py
@@ -1,4 +1,5 @@
 import collections
+import logging
 import typing as t
 
 import jmespath
@@ -10,6 +11,8 @@ from attrs import define
 from zyp.model.base import DictOrList
 from zyp.model.bucket import ConverterBase, MokshaTransformer, TransonTemplate
 from zyp.util.expression import compile_expression
+
+logger = logging.getLogger(__name__)
 
 
 @define
@@ -69,7 +72,12 @@ class MokshaTransformation(ConverterBase):
         self._add_rule(MokshaRule(type="transon", expression=expression))
         return self
 
-    def apply(self, data: DictOrList) -> DictOrList:
+    def apply(self, data: t.Any) -> t.Any:
         for rule in self._runtime_rules:
-            data = rule.evaluate(data)
+            try:
+                data = rule.evaluate(data)
+            except Exception:
+                logger.exception(f"Error evaluating rule: {rule}")
+                logger.debug(f"Error payload:\n{data}")
+                raise
         return data

--- a/tests/transform/mongodb/data.py
+++ b/tests/transform/mongodb/data.py
@@ -2,7 +2,8 @@
 A few samples of MongoDB BSON / JSON structures.
 
 Derived from:
-https://github.com/mongodb/bson-ruby/tree/v5.0.1/spec/spec_tests/data/corpus
+- https://github.com/mongodb/mongo-java-driver/tree/master/bson/src/test/resources/bson
+- https://github.com/mongodb/bson-ruby/tree/v5.0.1/spec/spec_tests/data/corpus
 """
 # ruff: noqa: ERA001
 
@@ -199,13 +200,13 @@ RECORD_OUT_ALL_TYPES = {
         "list_uuid": [
             # TODO: TypeError: Object of type bytes is not JSON serializable
             # b's\xff\xd2dD\xb3Li\x90\xe8\xe7\xd1\xdf\xc05\xd4',
-            "b's\\xff\\xd2dD\\xb3Li\\x90\\xe8\\xe7\\xd1\\xdf\\xc05\\xd4'",
-            "b's\\xff\\xd2dD\\xb3Li\\x90\\xe8\\xe7\\xd1\\xdf\\xc05\\xd4'",
-            "b's\\xff\\xd2dD\\xb3Li\\x90\\xe8\\xe7\\xd1\\xdf\\xc05\\xd4'",
+            "c//SZESzTGmQ6OfR38A11A==",
+            "c//SZESzTGmQ6OfR38A11A==",
+            "c//SZESzTGmQ6OfR38A11A==",
             "73ffc060-30b8-db47-2c20-8dfddbde3cdc",
-            "b's\\xff\\xc0`0\\xb8\\xdbG, \\x8d\\xfd\\xdb\\xde<\\xdc'",
-            "b's\\xff\\xc0`0\\xb8\\xdbG, \\x8d\\xfd\\xdb\\xde<\\xdc'",
-            "b's\\xff\\xc0`0\\xb8\\xdbG, \\x8d\\xfd\\xdb\\xde<\\xdc'",
+            "c//AYDC420csII3929483A==",
+            "c//AYDC420csII3929483A==",
+            "c//AYDC420csII3929483A==",
         ],
         "maxkey": "MaxKey()",
         "minkey": "MinKey()",

--- a/tests/transform/mongodb/test_mongodb_convert.py
+++ b/tests/transform/mongodb/test_mongodb_convert.py
@@ -1,35 +1,67 @@
 # ruff: noqa: E402
+import datetime as dt
+import typing as t
+
 import pytest
+from attrs import define
 
 pytestmark = pytest.mark.mongodb
 
-from commons_codec.transform.mongodb import MongoDBCrateDBConverter, date_converter
+from commons_codec.transform.mongodb import MongoDBCrateDBConverter
 from zyp.model.bucket import BucketTransformation, ValueConverter
 from zyp.model.collection import CollectionTransformation
 from zyp.model.treatment import Treatment
 
+convert_epoch = MongoDBCrateDBConverter.convert_epoch
+convert_iso8601 = MongoDBCrateDBConverter.convert_iso8601
 
-def test_date_converter_int():
+
+def test_epoch_ms_converter_int():
     """
     Datetime values encoded as integer values will be returned unmodified.
     """
-    assert date_converter(1443004362000) == 1443004362000
+    assert convert_epoch(1443004362) == 1443004362
+    assert convert_epoch(1443004362987) == 1443004362987
 
 
-def test_date_converter_iso8601():
+def test_epoch_ms_converter_iso8601():
     """
     Datetime values encoded as ISO8601 values will be parsed.
     """
-    assert date_converter("2015-09-23T10:32:42.33Z") == 1443004362000
-    assert date_converter(b"2015-09-23T10:32:42.33Z") == 1443004362000
+    assert convert_epoch("2015-09-23T10:32:42.33Z") == 1443004362
+    assert convert_epoch(b"2015-09-23T10:32:42.33Z") == 1443004362
 
 
-def test_date_converter_invalid():
+def test_epoch_ms_converter_invalid():
     """
     Incorrect datetime values will not be parsed.
     """
     with pytest.raises(ValueError) as ex:
-        date_converter(None)
+        convert_epoch(None)
+    assert ex.match("Unable to convert datetime value: None")
+
+
+def test_iso8601_converter_int():
+    """
+    Datetime values encoded as integer values will be returned unmodified.
+    """
+    assert convert_iso8601(1443004362) == "2015-09-23T10:32:42+00:00"
+
+
+def test_iso8601_converter_iso8601():
+    """
+    Datetime values encoded as ISO8601 values will be parsed.
+    """
+    assert convert_iso8601("2015-09-23T10:32:42.33Z") == "2015-09-23T10:32:42.33Z"
+    assert convert_iso8601(b"2015-09-23T10:32:42.33Z") == "2015-09-23T10:32:42.33Z"
+
+
+def test_iso8601_converter_invalid():
+    """
+    Incorrect datetime values will not be parsed.
+    """
+    with pytest.raises(ValueError) as ex:
+        convert_iso8601(None)
     assert ex.match("Unable to convert datetime value: None")
 
 
@@ -54,6 +86,65 @@ def test_convert_basic():
 
     converter = MongoDBCrateDBConverter()
     assert list(converter.decode_documents([data_in])) == [data_out]
+
+
+@define
+class DateConversionCase:
+    converter: t.Callable
+    data_in: t.Any
+    data_out: t.Any
+
+
+testdata = [
+    DateConversionCase(
+        converter=MongoDBCrateDBConverter(),
+        data_in={"$date": "2015-09-23T10:32:42.123456Z"},
+        data_out=dt.datetime(2015, 9, 23, 10, 32, 42, 123456),
+    ),
+    DateConversionCase(
+        converter=MongoDBCrateDBConverter(),
+        data_in={"$date": {"$numberLong": "1655210544987"}},
+        data_out=dt.datetime(2022, 6, 14, 12, 42, 24, 987000, tzinfo=dt.timezone.utc),
+    ),
+    DateConversionCase(
+        converter=MongoDBCrateDBConverter(timestamp_to_epoch=True, timestamp_use_milliseconds=True),
+        data_in={"$date": "2015-09-23T10:32:42.123456Z"},
+        data_out=1443004362000,
+    ),
+    DateConversionCase(
+        converter=MongoDBCrateDBConverter(timestamp_to_epoch=True, timestamp_use_milliseconds=True),
+        data_in={"$date": {"$numberLong": "1655210544987"}},
+        data_out=1655210544000,
+    ),
+    DateConversionCase(
+        converter=MongoDBCrateDBConverter(timestamp_to_iso8601=True),
+        data_in={"$date": "2015-09-23T10:32:42.123456Z"},
+        data_out="2015-09-23T10:32:42.123456",
+    ),
+    DateConversionCase(
+        converter=MongoDBCrateDBConverter(timestamp_to_iso8601=True),
+        data_in={"$date": {"$numberLong": "1655210544987"}},
+        data_out="2022-06-14T12:42:24.987000+00:00",
+    ),
+]
+
+
+testdata_ids = [
+    "vanilla-$date-canonical",
+    "vanilla-$date-legacy",
+    "epochms-$date-canonical",
+    "epochms-$date-legacy",
+    "iso8601-$date-canonical",
+    "iso8601-$date-legacy",
+]
+
+
+@pytest.mark.parametrize("testcase", testdata, ids=testdata_ids)
+def test_convert_timestamp_many(testcase: DateConversionCase):
+    """
+    Verify converting timestamps using different modifiers.
+    """
+    assert testcase.converter.decode_document(testcase.data_in) == testcase.data_out
 
 
 def test_convert_with_treatment_ignore_complex_lists():
@@ -83,7 +174,11 @@ def test_convert_with_treatment_ignore_complex_lists():
 
     treatment = Treatment(ignore_complex_lists=True)
     transformation = CollectionTransformation(treatment=treatment)
-    converter = MongoDBCrateDBConverter(transformation=transformation)
+    converter = MongoDBCrateDBConverter(
+        timestamp_to_epoch=True,
+        timestamp_use_milliseconds=True,
+        transformation=transformation,
+    )
     assert converter.decode_document(data_in) == data_out
 
 
@@ -119,7 +214,11 @@ def test_convert_with_treatment_normalize_complex_lists():
 
     treatment = Treatment(normalize_complex_lists=True)
     transformation = CollectionTransformation(treatment=treatment)
-    converter = MongoDBCrateDBConverter(transformation=transformation)
+    converter = MongoDBCrateDBConverter(
+        timestamp_to_epoch=True,
+        timestamp_use_milliseconds=True,
+        transformation=transformation,
+    )
     assert converter.decode_document(data_in) == data_out
 
 
@@ -165,7 +264,11 @@ def test_convert_with_treatment_all_options():
         ],
     )
     transformation = CollectionTransformation(treatment=treatment)
-    converter = MongoDBCrateDBConverter(transformation=transformation)
+    converter = MongoDBCrateDBConverter(
+        timestamp_to_epoch=True,
+        timestamp_use_milliseconds=True,
+        transformation=transformation,
+    )
     assert converter.decode_document(data_in) == data_out
 
 
@@ -180,6 +283,10 @@ def test_convert_transform_timestamp():
         values=ValueConverter().add(pointer="/timestamp", transformer="to_unixtime"),
     )
     transformation = CollectionTransformation(bucket=bucket_transformation)
-    converter = MongoDBCrateDBConverter(transformation=transformation)
+    converter = MongoDBCrateDBConverter(
+        timestamp_to_epoch=True,
+        timestamp_use_milliseconds=True,
+        transformation=transformation,
+    )
     data = converter.decode_documents(data_in)
     assert data == data_out

--- a/tests/transform/mongodb/test_mongodb_full.py
+++ b/tests/transform/mongodb/test_mongodb_full.py
@@ -43,7 +43,11 @@ def make_translator(kind: str) -> MongoDBFullLoadTranslator:
             .jq(".[] |= (.python.to_list |= to_array)")
             .jq(".[] |= (.python.to_string |= tostring)")
         )
-    converter = MongoDBCrateDBConverter(transformation=transformation)
+    converter = MongoDBCrateDBConverter(
+        timestamp_to_epoch=True,
+        timestamp_use_milliseconds=True,
+        transformation=transformation,
+    )
     translator = MongoDBFullLoadTranslator(table_name="from.mongodb", converter=converter)
     return translator
 

--- a/tests/zyp/moksha/test_jq.py
+++ b/tests/zyp/moksha/test_jq.py
@@ -188,13 +188,13 @@ def test_moksha_jq_cast_object_naive():
                 {"abc": {"id": 123}},
                 {"abc": {"id": 456}},
                 {"abc": {"id": 789}},
-                {"abc": {"id": None}},
-                {"abc": {"id": None}, "def": 999},
+                {},
+                {"def": 999},
             ]
         },
     ]
 
-    transformation = MokshaTransformation().jq('.[] |= (.data[].abc |= to_object({"key": "id"}))')
+    transformation = MokshaTransformation().jq('.[] |= (.data[].abc |= to_object({"key": "id", "zap": true}))')
     assert transformation.apply(data_in) == data_out
 
 


### PR DESCRIPTION
## About
Assorted "this and that" refinements.

## Details
- [MongoDB: Also decode non-UUID binary values](https://github.com/crate/commons-codec/commit/4e59c98058cc8bea4b0bf777dc729181d93350ba)
- [MongoDB: Satisfy mypy on MongoDBCrateDBConverter.decode_canonical](https://github.com/crate/commons-codec/pull/57/commits/6f75a106fe985690973bc81b6714871d61ac44ca)
- [MongoDB: Improve MongoDBCrateDBConverter.decode_extended_json](https://github.com/crate/commons-codec/pull/57/commits/5370381bb527c301cb516fc4f5fab5dc8b92d90f)
- [Zyp/Moksha/jq: to_object function now respects a zap option](https://github.com/crate/commons-codec/commit/403416594c452070f18c8beb804c66eb310a8401)
- [Zyp/Moksha/jq: Improve error reporting at MokshaTransformation.apply](https://github.com/crate/commons-codec/pull/57/commits/f97c040067b402428c0ef693efee86df4acf349f)