### PR TITLE
Zyp/Moksha: Improve error reporting when rule evaluation fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - DynamoDB CDC: Fix `MODIFY` operation by propagating `NewImage` fully
+- Zyp/Moksha: Improve error reporting when rule evaluation fails
 
 ## 2024/09/25 v0.0.18
 - MongoDB: Improved `MongoDBCrateDBConverter.decode_canonical` to also

--- a/src/zyp/model/moksha.py
+++ b/src/zyp/model/moksha.py
@@ -78,6 +78,8 @@ class MokshaTransformation(ConverterBase):
                 data = rule.evaluate(data)
             except Exception:
                 logger.exception(f"Error evaluating rule: {rule}")
+                if isinstance(data, map):
+                    data = list(data)
                 logger.debug(f"Error payload:\n{data}")
                 raise
         return data

--- a/tests/zyp/moksha/test_model.py
+++ b/tests/zyp/moksha/test_model.py
@@ -49,7 +49,7 @@ def test_moksha_transformation_success_jq():
     assert moksha.apply(4242) == 42.42
 
 
-def test_moksha_transformation_error_jq(caplog):
+def test_moksha_transformation_error_jq_scalar(caplog):
     moksha = MokshaTransformation().jq(". /= 100")
     with pytest.raises(ValueError) as ex:
         moksha.apply("foo")
@@ -57,6 +57,16 @@ def test_moksha_transformation_error_jq(caplog):
 
     assert "Error evaluating rule: MokshaRuntimeRule(type='jq'" in caplog.text
     assert "Error payload:\nfoo" in caplog.messages
+
+
+def test_moksha_transformation_error_jq_map(caplog):
+    moksha = MokshaTransformation().jq(".foo")
+    with pytest.raises(ValueError) as ex:
+        moksha.apply(map(lambda x: x, ["foo"]))  # noqa: C417
+    assert ex.match(re.escape('Cannot index array with string "foo"'))
+
+    assert "Error evaluating rule: MokshaRuntimeRule(type='jq'" in caplog.text
+    assert "Error payload:\n[]" in caplog.messages
 
 
 def test_moksha_transformation_empty():


### PR DESCRIPTION
## About
When transformation payload is a `map()`, and jqlang rule evaluation fails, improve error reporting.