### PR TITLE
DynamoDB: Change CrateDB data model to use (`pk`, `data`, `aux`) columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- DynamoDB: Change CrateDB data model to use (`pk`, `data`, `aux`) columns
+  Attention: This is a breaking change.
 
 ## 2024/09/26 v0.0.19
 - DynamoDB CDC: Fix `MODIFY` operation by propagating `NewImage` fully

--- a/src/commons_codec/model.py
+++ b/src/commons_codec/model.py
@@ -131,14 +131,15 @@ class SQLParameterizedWhereClause(SQLParameterizedClause):
 
 
 @define
-class DualRecord:
+class UniversalRecord:
     """
-    Manage two halves of a record.
+    Manage a universal record including primary keys and two halves of a record.
     One bucket stores the typed fields, the other stores the untyped ones.
     """
 
+    pk: t.Dict[str, t.Any]
     typed: t.Dict[str, t.Any]
     untyped: t.Dict[str, t.Any]
 
     def to_dict(self):
-        return {"typed": self.typed, "untyped": self.untyped}
+        return {"pk": self.pk, "typed": self.typed, "untyped": self.untyped}

--- a/src/commons_codec/transform/dynamodb_model.py
+++ b/src/commons_codec/transform/dynamodb_model.py
@@ -1,0 +1,82 @@
+import sys
+import typing as t
+
+from attr import Factory, define
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum  # pragma: no cover
+
+
+class AttributeType(StrEnum):
+    STRING = "STRING"
+    NUMBER = "NUMBER"
+    BINARY = "BINARY"
+
+
+DYNAMODB_TYPE_MAP = {
+    "S": AttributeType.STRING,
+    "N": AttributeType.NUMBER,
+    "B": AttributeType.BINARY,
+}
+
+CRATEDB_TYPE_MAP = {
+    AttributeType.STRING: "STRING",
+    AttributeType.NUMBER: "BIGINT",
+    AttributeType.BINARY: "STRING",
+}
+
+
+@define
+class Attribute:
+    name: str
+    type: AttributeType
+
+    @classmethod
+    def from_dynamodb(cls, name: str, type_: str):
+        try:
+            return cls(name=name, type=DYNAMODB_TYPE_MAP[type_])
+        except KeyError as ex:
+            raise KeyError(f"Mapping DynamoDB type failed: name={name}, type={type_}") from ex
+
+    @property
+    def cratedb_type(self):
+        return CRATEDB_TYPE_MAP[self.type]
+
+
+@define
+class PrimaryKeySchema:
+    schema: t.List[Attribute] = Factory(list)
+
+    def add(self, name: str, type: str) -> "PrimaryKeySchema":  # noqa: A002
+        self.schema.append(Attribute.from_dynamodb(name, type))
+        return self
+
+    @classmethod
+    def from_table(cls, table) -> "PrimaryKeySchema":
+        """
+        # attribute_definitions: [{'AttributeName': 'Id', 'AttributeType': 'N'}]
+        # key_schema: [{'AttributeName': 'Id', 'KeyType': 'HASH'}]
+        """
+
+        schema = cls()
+        attribute_type_map: t.Dict[str, str] = {}
+        for attr in table.attribute_definitions:
+            attribute_type_map[attr["AttributeName"]] = attr["AttributeType"]
+
+        for key in table.key_schema:
+            name = key["AttributeName"]
+            type_ = attribute_type_map[name]
+            schema.add(name=name, type=type_)
+
+        return schema
+
+    def keys(self) -> t.List[str]:
+        return [attribute.name for attribute in self.schema]
+
+    def column_names(self) -> t.List[str]:
+        return [f'"{attribute.name}"' for attribute in self.schema]
+
+    def to_sql_ddl_clauses(self) -> t.List[str]:
+        return [f'"{attribute.name}" {attribute.cratedb_type} PRIMARY KEY' for attribute in self.schema]

--- a/tests/transform/conftest.py
+++ b/tests/transform/conftest.py
@@ -1,5 +1,8 @@
 import pytest
 
+from commons_codec.transform.dynamodb import DynamoDBCDCTranslator, DynamoDBFullLoadTranslator
+from commons_codec.transform.dynamodb_model import PrimaryKeySchema
+
 RESET_TABLES = [
     "from.dynamodb",
     "from.mongodb",
@@ -13,3 +16,13 @@ def cratedb(cratedb_service):
     """
     cratedb_service.reset(tables=RESET_TABLES)
     yield cratedb_service
+
+
+@pytest.fixture
+def dynamodb_full_translator_foo():
+    return DynamoDBFullLoadTranslator(table_name="foo", primary_key_schema=PrimaryKeySchema().add("id", "S"))
+
+
+@pytest.fixture
+def dynamodb_cdc_translator_foo():
+    return DynamoDBCDCTranslator(table_name="foo")

--- a/tests/transform/test_dynamodb_full.py
+++ b/tests/transform/test_dynamodb_full.py
@@ -41,8 +41,11 @@ RECORD_IN = {
     "set_of_strings": {"SS": ["location_1"]},
 }
 
-RECORD_OUT_DATA = {
+RECORD_OUT_PK = {
     "id": "5F9E-Fsadd41C-4C92-A8C1-70BF3FFB9266",
+}
+
+RECORD_OUT_DATA = {
     "data": {"temperature": 42.42, "humidity": 84.84},
     "meta": {"timestamp": "2024-07-12T01:17:42", "device": "foo"},
     "location": {
@@ -76,21 +79,29 @@ RECORD_OUT_AUX = {
 }
 
 
-def test_sql_ddl():
+def test_sql_ddl_success(dynamodb_full_translator_foo):
     assert (
-        DynamoDBFullLoadTranslator(table_name="foo").sql_ddl
-        == "CREATE TABLE IF NOT EXISTS foo (data OBJECT(DYNAMIC), aux OBJECT(IGNORED));"
+        dynamodb_full_translator_foo.sql_ddl == "CREATE TABLE IF NOT EXISTS foo "
+        '(pk OBJECT(STRICT) AS ("id" STRING PRIMARY KEY), data OBJECT(DYNAMIC), aux OBJECT(IGNORED));'
     )
 
 
-def test_to_sql_operation():
+def test_sql_ddl_failure(dynamodb_full_translator_foo):
+    translator = DynamoDBFullLoadTranslator(table_name="foo")
+    with pytest.raises(IOError) as ex:
+        _ = translator.sql_ddl
+    assert ex.match("Unable to generate SQL DDL without key schema information")
+
+
+def test_to_sql_operation(dynamodb_full_translator_foo):
     """
     Verify outcome of `DynamoDBFullLoadTranslator.to_sql` operation.
     """
-    assert DynamoDBFullLoadTranslator(table_name="foo").to_sql(RECORD_IN) == SQLOperation(
-        statement="INSERT INTO foo (data, aux) VALUES (:typed, :untyped);",
+    assert dynamodb_full_translator_foo.to_sql(RECORD_IN) == SQLOperation(
+        statement="INSERT INTO foo (pk, data, aux) VALUES (:pk, :typed, :untyped);",
         parameters=[
             {
+                "pk": RECORD_OUT_PK,
                 "typed": RECORD_OUT_DATA,
                 "untyped": RECORD_OUT_AUX,
             }
@@ -99,13 +110,15 @@ def test_to_sql_operation():
 
 
 @pytest.mark.integration
-def test_to_sql_cratedb(caplog, cratedb):
+def test_to_sql_cratedb(caplog, cratedb, dynamodb_full_translator_foo):
     """
     Verify writing converted DynamoDB record to CrateDB.
     """
 
     # Compute CrateDB operation (SQL+parameters) from DynamoDB record.
-    translator = DynamoDBFullLoadTranslator(table_name="from.dynamodb")
+    translator = DynamoDBFullLoadTranslator(
+        table_name="from.dynamodb", primary_key_schema=dynamodb_full_translator_foo.primary_key_schema
+    )
     operation = translator.to_sql(RECORD_IN)
 
     # Insert into CrateDB.
@@ -118,5 +131,6 @@ def test_to_sql_cratedb(caplog, cratedb):
     assert cratedb.database.count_records("from.dynamodb") == 1
 
     results = cratedb.database.run_sql('SELECT * FROM "from".dynamodb;', records=True)  # noqa: S608
+    assert results[0]["pk"] == RECORD_OUT_PK
     assert results[0]["data"] == RECORD_OUT_DATA
     assert results[0]["aux"] == RECORD_OUT_AUX

--- a/tests/transform/test_dynamodb_model.py
+++ b/tests/transform/test_dynamodb_model.py
@@ -1,0 +1,31 @@
+import pytest
+
+from commons_codec.transform.dynamodb_model import PrimaryKeySchema
+
+
+def test_primary_key_schema_from_table_success():
+    class SurrogateTable:
+        attribute_definitions = [
+            {"AttributeName": "Id", "AttributeType": "N"},
+        ]
+        key_schema = [
+            {"AttributeName": "Id", "KeyType": "HASH"},
+        ]
+
+    pks = PrimaryKeySchema.from_table(SurrogateTable())
+    assert pks == PrimaryKeySchema().add("Id", "N")
+    assert pks.column_names() == ['"Id"']
+
+
+def test_primary_key_schema_from_table_unknown_type():
+    class SurrogateTable:
+        attribute_definitions = [
+            {"AttributeName": "Id", "AttributeType": "F"},
+        ]
+        key_schema = [
+            {"AttributeName": "Id", "KeyType": "HASH"},
+        ]
+
+    with pytest.raises(KeyError) as ex:
+        PrimaryKeySchema.from_table(SurrogateTable())
+    assert ex.match("Mapping DynamoDB type failed: name=Id, type=F")

--- a/tests/transform/test_dynamodb_types_cratedb.py
+++ b/tests/transform/test_dynamodb_types_cratedb.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 
 import pytest
 
-from commons_codec.model import DualRecord
-from commons_codec.transform.dynamodb import CrateDBTypeDeserializer, DynamoDBCDCTranslator
+from commons_codec.model import UniversalRecord
+from commons_codec.transform.dynamodb import CrateDBTypeDeserializer
 
 pytestmark = pytest.mark.dynamodb
 
@@ -21,7 +21,7 @@ class TestDeserializer(unittest.TestCase):
         ]
 
 
-def test_decode_typed_untyped():
-    assert DynamoDBCDCTranslator(table_name="foo").decode_record(
+def test_decode_typed_untyped(dynamodb_cdc_translator_foo):
+    assert dynamodb_cdc_translator_foo.decode_record(
         {"foo": {"N": "84.84"}, "bar": {"L": [{"N": "1"}, {"S": "foo"}]}}
-    ) == DualRecord(typed={"foo": 84.84}, untyped={"bar": [1.0, "foo"]})
+    ) == UniversalRecord(pk={}, typed={"foo": 84.84}, untyped={"bar": [1.0, "foo"]})


### PR DESCRIPTION
## About
By breaking the primary key information out of the main record's data bucket, the main record can be updated as-is on CDC MODIFY operations.

## References
- https://github.com/crate/cratedb-toolkit/pull/281