### PR TITLE
DynamoDB and MongoDB: Fix CI and improve decoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- MongoDB: Fixed BSON decoding of `{"$date": 1180690093000}` timestamps
+- DynamoDB: Use CrateDB 5.8.3 for testing because 5.8.4 can no longer
+  store `ARRAY`s with varying inner types into `OBJECT(IGNORED)` columns.
 
 ## 2024/09/30 v0.0.20
 - DynamoDB: Change CrateDB data model to use (`pk`, `data`, `aux`) columns

--- a/tests/transform/conftest.py
+++ b/tests/transform/conftest.py
@@ -10,12 +10,25 @@ RESET_TABLES = [
 
 
 @pytest.fixture(scope="function")
-def cratedb(cratedb_service):
+def cratedb_custom_service():
+    """
+    Provide a CrateDB service instance to the test suite.
+    """
+    from cratedb_toolkit.testing.testcontainers.cratedb import CrateDBTestAdapter
+
+    db = CrateDBTestAdapter(crate_version="5.8.3")
+    db.start()
+    yield db
+    db.stop()
+
+
+@pytest.fixture(scope="function")
+def cratedb(cratedb_custom_service):
     """
     Provide a fresh canvas to each test case invocation, by resetting database content.
     """
-    cratedb_service.reset(tables=RESET_TABLES)
-    yield cratedb_service
+    cratedb_custom_service.reset(tables=RESET_TABLES)
+    yield cratedb_custom_service
 
 
 @pytest.fixture

--- a/tests/transform/mongodb/test_mongodb_convert.py
+++ b/tests/transform/mongodb/test_mongodb_convert.py
@@ -104,7 +104,7 @@ testdata = [
     DateConversionCase(
         converter=MongoDBCrateDBConverter(),
         data_in={"$date": {"$numberLong": "1655210544987"}},
-        data_out=dt.datetime(2022, 6, 14, 12, 42, 24, 987000, tzinfo=dt.timezone.utc),
+        data_out=dt.datetime(2022, 6, 14, 12, 42, 24, 987000),
     ),
     DateConversionCase(
         converter=MongoDBCrateDBConverter(timestamp_to_epoch=True, timestamp_use_milliseconds=True),
@@ -124,7 +124,12 @@ testdata = [
     DateConversionCase(
         converter=MongoDBCrateDBConverter(timestamp_to_iso8601=True),
         data_in={"$date": {"$numberLong": "1655210544987"}},
-        data_out="2022-06-14T12:42:24.987000+00:00",
+        data_out="2022-06-14T12:42:24.987000",
+    ),
+    DateConversionCase(
+        converter=MongoDBCrateDBConverter(timestamp_to_iso8601=True),
+        data_in={"$date": 1180690093000},
+        data_out="2007-06-01T09:28:13",
     ),
 ]
 
@@ -136,6 +141,7 @@ testdata_ids = [
     "epochms-$date-legacy",
     "iso8601-$date-canonical",
     "iso8601-$date-legacy",
+    "iso8601-$date-ultra-legacy",
 ]
 
 


### PR DESCRIPTION
## About
- [MongoDB: Fixed BSON decoding of {"$date": 1180690093000} timestamps](https://github.com/crate/commons-codec/commit/865b73357fabc0af590a1c9a7263b78b14f1431c)
- [DynamoDB: Use CrateDB 5.8.3 for testing. 5.8.4 caught a regression](https://github.com/crate/commons-codec/commit/d2214fb234b17b24daa0930d32e254f3248bf233)