### PR TITLE
DynamoDB: Use `ON CONFLICT DO NOTHING` clause on `INSERT` CDC operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 - DynamoDB/Testing: Use CrateDB nightly again
+- DynamoDB: Use `ON CONFLICT DO NOTHING` clause on CDC operations
+  of type `INSERT`, to mitigate errors when events are relayed
+  redundantly from retries after partially failed batches on the
+  Lambda processor.
 
 ## 2024/10/09 v0.0.21
 - MongoDB: Fixed BSON decoding of `{"$date": 1180690093000}` timestamps

--- a/src/commons_codec/transform/dynamodb.py
+++ b/src/commons_codec/transform/dynamodb.py
@@ -201,7 +201,8 @@ class DynamoDBCDCTranslator(DynamoTranslatorBase):
                 f") VALUES ("
                 f":pk, "
                 f":typed, "
-                f":untyped);"
+                f":untyped) "
+                f"ON CONFLICT DO NOTHING;"
             )
             parameters = record.to_dict()
 


### PR DESCRIPTION
## Reason
... to mitigate errors when events are relayed redundantly from retries after partially failed batches on the Lambda processor.

## References
- https://github.com/crate/cratedb-toolkit/issues/301

/cc @kneth, @surister, @hlcianfagna  