### PR TITLE
DMS: Fix primary key / where clause rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - CI: Added support for Python 3.13
 - DMS: Fixed handling of primary keys
 - DMS: Added support for the previously missing `drop-table` operation
+- DMS: Fixed primary key / where clause rendering
 
 ## 2024/10/28 v0.0.22
 - DynamoDB/Testing: Use CrateDB nightly again

--- a/src/commons_codec/transform/aws_dms.py
+++ b/src/commons_codec/transform/aws_dms.py
@@ -92,7 +92,7 @@ class DMSTranslatorCrateDBRecord:
         if self.operation == "create-table":
             return SQLOperation(
                 f"CREATE TABLE IF NOT EXISTS {self.address.fqn} ("
-                f"{self.pk_clause()}"
+                f"{self.PK_COLUMN} OBJECT(STRICT){self.pk_clause()}, "
                 f"{self.TYPED_COLUMN} OBJECT(DYNAMIC), "
                 f"{self.UNTYPED_COLUMN} OBJECT(IGNORED));"
             )
@@ -151,7 +151,7 @@ class DMSTranslatorCrateDBRecord:
                 ltype = col_meta.get("type", "TEXT")
                 pk_clauses.append(f'"{pk_name}" {self.resolve_type(ltype)} PRIMARY KEY')
             if pk_clauses:
-                return f"{self.PK_COLUMN} OBJECT(STRICT) AS ({', '.join(pk_clauses)}), "
+                return f" AS ({', '.join(pk_clauses)})"
         return ""
 
     @staticmethod
@@ -229,7 +229,8 @@ class DMSTranslatorCrateDBRecord:
         clause = SQLParameterizedWhereClause()
         for key_name in self.primary_keys:
             key_value = self.data.get(key_name)
-            clause.add(lval=f"{self.TYPED_COLUMN}['{key_name}']", value=key_value, name=key_name)
+            if key_value is not None:
+                clause.add(lval=f"{self.PK_COLUMN}['{key_name}']", value=key_value, name=key_name)
         return clause
 
 

--- a/tests/transform/test_aws_dms.py
+++ b/tests/transform/test_aws_dms.py
@@ -241,7 +241,8 @@ def test_decode_cdc_sql_ddl_regular_drop(cdc):
 
 def test_decode_cdc_sql_ddl_awsdms(cdc):
     assert cdc.to_sql(MSG_CONTROL_AWSDMS) == SQLOperation(
-        statement="CREATE TABLE IF NOT EXISTS dms.awsdms_apply_exceptions (data OBJECT(DYNAMIC), aux OBJECT(IGNORED));",
+        statement="CREATE TABLE IF NOT EXISTS dms.awsdms_apply_exceptions "
+        "(pk OBJECT(STRICT), data OBJECT(DYNAMIC), aux OBJECT(IGNORED));",
         parameters=None,
     )
 
@@ -283,7 +284,7 @@ def test_decode_cdc_update_success(cdc):
     assert cdc.to_sql(MSG_DATA_UPDATE_VALUE) == SQLOperation(
         statement="UPDATE public.foo SET "
         "data['age']=:age, data['attributes']=:attributes, data['name']=:name "
-        "WHERE data['id']=:id;",
+        "WHERE pk['id']=:id;",
         parameters=RECORD_UPDATE,
     )
 
@@ -310,7 +311,7 @@ def test_decode_cdc_delete_success(cdc):
 
     # Emulate a DELETE operation.
     assert cdc.to_sql(MSG_DATA_DELETE) == SQLOperation(
-        statement="DELETE FROM public.foo WHERE data['id']=:id;", parameters={"id": 45}
+        statement="DELETE FROM public.foo WHERE pk['id']=:id;", parameters={"id": 45}
     )
 
 


### PR DESCRIPTION
## About

A few more fixes about processing CDC events from DMS/Kinesis regarding the "universal" column mapping paradigm.

## References

- GH-110
